### PR TITLE
hmm.cabal: relax lower bounds on bytestring and containers

### DIFF
--- a/hmm.cabal
+++ b/hmm.cabal
@@ -16,7 +16,7 @@ Library
   Build-Depends: 
                  base,logfloat,data-memocombinators,list-extras,array,
                  binary >=0.7.1 && <0.8,
-                 bytestring >=0.10.0 && <0.11,
-                 containers >=0.5.0 && <0.6
+                 bytestring >=0.9.0 && <0.11,
+                 containers >=0.4.2 && <0.6
   Exposed-modules:
     Data.HMM


### PR DESCRIPTION
This way the package can be compiled on GHC-7.4.2.