### PR TITLE
some changes that avoid warnings

### DIFF
--- a/Data/HMM.hs
+++ b/Data/HMM.hs
@@ -19,18 +19,15 @@ module Data.HMM
 import Debug.Trace
 import Data.Array
 import Data.List
-import Data.List.Extras
+import Data.List.Extras (argmax)
 import Data.Number.LogFloat
 import qualified Data.MemoCombinators as Memo
--- import Control.Parallel
 import System.IO
--- import Text.ParserCombinators.Parsec
 import Data.Binary
 import Control.Monad (liftM)
 import Control.Applicative ((<*>), (<$>))
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.Map as M 
-import Data.Maybe (fromJust)
 
 type Prob = LogFloat
 

--- a/Data/HMM.hs
+++ b/Data/HMM.hs
@@ -302,6 +302,7 @@ hmmJoin hmm1 hmm2 ratio = HMM { states = states1 ++ states2
 --                                         lift x =read $ (snd x )
 
 -- debug utils
+hmmid :: HMM stateType eventType -> String
 hmmid hmm = show $ initProbs hmm $ (states hmm) !! 1
 
 -- | tests
@@ -314,15 +315,25 @@ listCPExp language order = listCPExp' order [[]]
             | otherwise     = listCPExp' (order-1) [symbol:l | l <- list, symbol <- language]
 
 -- | should always equal 1
+forwardtest ::
+    (Eq stateType, Eq eventType, Show stateType, Show eventType) =>
+    HMM stateType eventType -> Int -> Prob
 forwardtest hmm x = sum [forward hmm e | e <- listCPExp (events hmm) x]
 
 -- | should always equal 1
+backwardtest ::
+    (Eq stateType, Eq eventType, Show stateType, Show eventType) =>
+    HMM stateType eventType -> Int -> Prob
 backwardtest hmm x = sum [backward hmm e | e <- listCPExp (events hmm) x]
 
 -- | should always equal each other
+fbtest ::
+    (Eq stateType, Eq eventType, Show stateType, Show eventType) =>
+    HMM stateType eventType -> [eventType] -> String
 fbtest hmm events = "fwd: " ++ show (forward hmm events) ++ " bkwd:" ++ show (backward hmm  events)
     
 -- | initProbs should always equal 1; the others should equal the number of states
+verifyhmm :: HMM stateType eventType -> IO ()
 verifyhmm hmm = do
         seq ip $ check "initProbs" ip
         check "transMatrix" tm

--- a/Data/HMM.hs
+++ b/Data/HMM.hs
@@ -46,7 +46,10 @@ data HMM stateType eventType = HMM { states :: [stateType]
 
 instance (Show stateType, Show eventType) => Show (HMM stateType eventType) where
     show hmm = hmm2str hmm 
-    
+
+hmm2str ::
+    (Show stateType, Show eventType) =>
+    HMM stateType eventType -> String
 hmm2str hmm = "HMM" ++ "{ states=" ++ (show $ states hmm) 
                      ++ ", events=" ++ (show $ events hmm) 
                      ++ ", initProbs=" ++ (show [(s,initProbs hmm s) | s <- states hmm])
@@ -70,6 +73,9 @@ eventIndex hmm event = case elemIndex event $ events hmm of
                             Just x -> x
 
 -- | Use simpleMM to create an untrained standard Markov model
+simpleMM ::
+    (Eq a, Show a, Eq i, Num i) =>
+    [a] -> i -> HMM [a] a
 simpleMM eL order = HMM { states = sL
                         , events = eL
                         , initProbs = \s -> evenDist--skewedDist s


### PR DESCRIPTION
remaining warnings should be addressed by:

move
  instance Read LogFloat and
  instance Binary LogFloat
to the logfloat package

move test functions to a separate module
   and maybe turn them into a testsuite that can be run by Cabal